### PR TITLE
Sketch 1.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 * String "bomberosrcv"          //bomberos recibido confirmacion - enviado de servidor de forma automática.
 * String "medicarcv"            //medica recibido confirmacion - enviado de servidor de forma automática.
 * String "atendidorcv"          //Respuesta de operario, alerta atendida - enviado por operario de forma manual.
+* String "informadorcv"         //informadorcv cuando se da aviso a la policia. Activa un temporizador para apagar todos los leds.
+* String "cerradorcv"           //Es cuando se da por finalizada la alerta, pero puede pasar mucho tiempo. Todavia sin funcionalidad en el módulo.
 *******************************
 ## MENSAJES ENVIADOS LORA
 * char "Lpolicia"	- Base64: THBvbGljaWE=	//mensaje1 para enviar por lora.

--- a/Sketchup/Panic_Button/Panic_Button.ino
+++ b/Sketchup/Panic_Button/Panic_Button.ino
@@ -2,6 +2,7 @@
 * V1.8.2: 
 * Se agregan nuevos mensajes recibidos: "informadorcv" y "cerradorcv". cerradorcv sin función aun.
 * Ahora rcv_informado apaga todos los leds luego de 15 segundos de recibir el mensaje. A futuro se aumentara este tiempo.
+* Se reduce a 3 segundos el tiempo del blinkstb.
 */
 
 //librerias utilizadas

--- a/Sketchup/Panic_Button/Task.h
+++ b/Sketchup/Panic_Button/Task.h
@@ -1,8 +1,8 @@
 #include "pinout.h"
 
 unsigned long previousMillis = 0;         // Variable para almacenar el tiempo anterior
-#define ledOnTime   500      // Tiempo de encendido en milisegundos (0.5 segundos)
-#define ledOffTime  10000   // Tiempo de apagado en milisegundos (5 segundos)
+#define ledOnTime   300      // Tiempo de encendido en milisegundos (0.5 segundos)
+#define ledOffTime  3000   // Tiempo de apagado en milisegundos (3 segundos)
 bool LED_state = LOW;                     // Estado actual del LED
 
 #define delay_apagarLED   15000            //delay para apagar el led despues que se encendio por recibir un mensaje de confirmacion

--- a/Sketchup/Panic_Button/Task.ino
+++ b/Sketchup/Panic_Button/Task.ino
@@ -28,16 +28,14 @@ void led_blink() {
 //TASK2:  blink de stand by, es un blink de baja frecuencia para indicar que el dispositivo esta funcionando.
 void blinkstb() {                       
   unsigned long currentMillis = millis();
-
   if (LED_state == HIGH && (currentMillis - previousMillis >= ledOnTime)) {
-    // Apagar el LED después de 0.5 segundos
+    // Apagar el LED después de 0.3 segundos
     LED_state = LOW;                  // Cambiar estado del LED
     previousMillis = currentMillis;   // Actualizar tiempo anterior
     digitalWrite(led_powerON, LED_state);  // Apagar el LED
-    //Serial.println("blink blink");
-    
-  } else if (LED_state == LOW && (currentMillis - previousMillis >= ledOffTime)) {
-    // Encender el LED después de 7 segundos
+  } 
+  else if (LED_state == LOW && (currentMillis - previousMillis >= ledOffTime)) {
+    // Encender el LED después de 3 segundos
     LED_state = HIGH;                 // Cambiar estado del LED
     previousMillis = currentMillis;   // Actualizar tiempo anterior
     digitalWrite(led_powerON, LED_state);  // Encender el LED

--- a/VERSION.md
+++ b/VERSION.md
@@ -68,3 +68,4 @@ por baja tension que genera el modulo SIM800.
 * V1.8.2
 * * Se agregan nuevos mensajes recibidos: "informadorcv" y "cerradorcv". cerradorcv sin función aun.
 * * Ahora rcv_informado apaga todos los leds luego de 15 segundos de recibir el mensaje. A futuro se aumentara este tiempo.
+* * Se reduce a 3 segundos el tiempo del blinkstb.


### PR DESCRIPTION
* V1.8.2
* * Se agregan nuevos mensajes recibidos: "informadorcv" y "cerradorcv". cerradorcv sin función aun.
* * Ahora rcv_informado apaga todos los leds luego de 15 segundos de recibir el mensaje. A futuro se aumentara este tiempo.
* * Se reduce a 3 segundos el tiempo del blinkstb.
* * Se actualiza readme.